### PR TITLE
Removes ads-release meta package, fixes bug where build folder was being deleted post script completion

### DIFF
--- a/.github/workflows/build_sources.yml
+++ b/.github/workflows/build_sources.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Execute Python Package Builder
         run: |
           python3 -u build_scripts/main.py
-          tree .
+          pwd && tree .
 
       - name: Commit files
         run: |

--- a/.github/workflows/build_sources.yml
+++ b/.github/workflows/build_sources.yml
@@ -42,6 +42,6 @@ jobs:
           shopt -s globstar
           rm -r !(ubuntu|README.md|cache.yaml)
           git add -A
-          git rm -rf .gitmodules .github .gitignore
+          git rm -rf --ignore-unmatch .gitmodules .github .gitignore
           git commit -m "Updated debs"
           git push -f --set-upstream origin website

--- a/README.md
+++ b/README.md
@@ -11,16 +11,19 @@ Install needed programs
 sudo apt install -y curl gpg
 ```
 
-Download of the key and `source.list`
+Download `appcove-developer-software.list` and add to your package source. Then download and install the necessary GPG key to verify packages.
+
 ``` bash
-curl -sLO https://appcove.github.io/developer-software/ubuntu/dists/jammy/main/binary-amd64/ads-release_1.0.1custom22.04_amd64.deb
-sudo dpkg -i ads-release_1.0.1custom22.04_amd64.deb
+sudo curl -s --compressed -o /etc/apt/sources.list.d/appcove-developer-software.list "https://appcove.github.io/developer-software/ubuntu/dists/stable/appcove-developer-software.list"
+
+curl -s --compressed "https://appcove.github.io/developer-software/ubuntu/KEY.gpg" | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/appcove-developer-software.gpg
+
 sudo apt update
 ```
+
 ❗**Log out and log back in for systemwide changes to be applied**, then try to install one of our tools: `sudo apt install git-excess`
 
-
-Install everything: 
+Install everything:
 ```
 sudo apt install ads-everything
 ```
@@ -30,7 +33,7 @@ sudo apt install ads-everything
 sudo apt list "ads-*"
 ```
 Should output
-- ads-release - This package installs the needed files for the PPA to work correctly
+- [ads-everything] - Meta-package that adds `/opt/ads/bin` to $PATH and installs all other `ads-*` packages as dependencies.
 - [ads-git-excess](https://github.com/appcove/git-excess)
 - [ads-pastel](https://github.com/sharkdp/pastel)
 - [ads-fd](https://github.com/sharkdp/fd)
@@ -47,7 +50,7 @@ Should output
 - [ads-et](https://github.com/solidiquis/erdtree) - A modern, vibrant, and multi-threaded file-tree visualizer and disk usage analyzer
 - [ads-delta](https://github.com/dandavison/delta) - Modern CLI git diff analizer (requires manual setup LOOK BELOW)
 
-# Examples 
+# Examples
 <details><summary>fd</summary>
 
 ![fd-example](doc/fd-example.svg)
@@ -58,7 +61,7 @@ Should output
 
 ![bat-example](doc/bat-example.png)
 
-``` bash 
+``` bash
 bat src/*.rs # show multiple files at once
 bat header.md content.md footer.md > document.md
 bat -n main.rs  # show line numbers (only)
@@ -70,7 +73,7 @@ bat -n main.rs  # show line numbers (only)
 <details><summary>procs</summary>
 
 
-``` bash 
+``` bash
 procs # list all processes
 procs <executable>  # `procs chrome` list all processes of application
 procs --tree
@@ -110,7 +113,7 @@ procs --tree
 
 ![dust example](doc/dust-example.png)
 
-``` shell 
+``` shell
 Usage: dust
 Usage: dust <dir>
 Usage: dust <dir>  <another_dir> <and_more>
@@ -160,7 +163,7 @@ Install it and then add this to your `~/.gitconfig`:
 ```
 
 </details>
-   
-   
+
+
 
 

--- a/build_scripts/common.py
+++ b/build_scripts/common.py
@@ -77,14 +77,14 @@ class Package(object):
 # Rust Packages insalled from crates.io using the `cargo install` command
 class RustPackage(Package):
     def build(self):
-        BUILD_FOLDER = f"temp/ads-{self.package_name}_{self.version}custom{UBUNTU_VERSION}_{self.arch}"
+        BUILD_FOLDER = f"build/ads-{self.package_name}_{self.version}custom{UBUNTU_VERSION}_{self.arch}"
 
         # cargo-install
-        commands = ["cargo", "install", "--locked", "--quiet", f"{self.package_name}@{self.version}", "--root", "temp/cargo-install"]
+        commands = ["cargo", "install", "--locked", "--quiet", f"{self.package_name}@{self.version}", "--root", "build/cargo-install"]
 
         # sources from a git repository
         if self.git:
-            commands = ["cargo", "install", "--locked", "--quiet", "--git", self.git, "--root", "temp/cargo-install", *self.binaries]
+            commands = ["cargo", "install", "--locked", "--quiet", "--git", self.git, "--root", "build/cargo-install", *self.binaries]
             pass
 
         # let's gooo
@@ -97,7 +97,7 @@ class RustPackage(Package):
         # Write out binaries
         print(f"[*] Copying binaries - [{", ".join(self.binaries)}]")
         for bin in self.binaries:
-            path = f"temp/cargo-install/bin/{bin}"
+            path = f"build/cargo-install/bin/{bin}"
             shutil.copy(path, target_folder)
 
         Path(f'{BUILD_FOLDER}/DEBIAN').mkdir(parents=True, exist_ok=True)
@@ -106,14 +106,14 @@ class RustPackage(Package):
 
 class Release(Package):
     def build(self):
-        BUILD_FOLDER = f"temp/ads-{self.package_name}_{self.version}custom{UBUNTU_VERSION}_{self.arch}"
+        BUILD_FOLDER = f"build/ads-{self.package_name}_{self.version}custom{UBUNTU_VERSION}_{self.arch}"
 
         # add path to bins
         Path(f'./{BUILD_FOLDER}/etc/profile.d').mkdir(parents=True, exist_ok=True)
         with open(f'{BUILD_FOLDER}/etc/profile.d/10-ads-release.sh', "w") as release_file:
             release_file.write("export PATH=\"$PATH:/opt/ads/bin\"")
 
-            # add key and list file
+        # add key and list file
         Path(f'{BUILD_FOLDER}/DEBIAN').mkdir(parents=True, exist_ok=True)
         with open(f'{BUILD_FOLDER}/DEBIAN/postinst', "w") as release_file:
             release_file.write("""
@@ -128,7 +128,7 @@ sudo curl -s --compressed -o /etc/apt/sources.list.d/appcove-developer-software.
 
 class InstallAll(Package):
     def build(self):
-        BUILD_FOLDER = f"temp/ads-{self.package_name}_{self.version}custom{UBUNTU_VERSION}_{self.arch}"
+        BUILD_FOLDER = f"build/ads-{self.package_name}_{self.version}custom{UBUNTU_VERSION}_{self.arch}"
 
         Path(f'{BUILD_FOLDER}/DEBIAN').mkdir(parents=True, exist_ok=True)
         with open(f'{BUILD_FOLDER}/DEBIAN/postinst', "w") as release_file:
@@ -149,7 +149,7 @@ def write_control_file(path, package_info: Package):
     Path(f"{path}/DEBIAN").mkdir(parents=True, exist_ok=True)
 
     print(f"[*] Writing Control File - {path}/DEBIAN/control")
-    with open(f"{path}/DEBIAN/control", 'x') as f:
+    with open(f"{path}/DEBIAN/control", 'w') as f:
         f.write(f'Package: ads-{package_info.package_name}\n')
         f.write(f'Version: {package_info.version}custom{UBUNTU_VERSION}\n')
         f.write(f'Maintainer: {package_info.maintainer}\n')
@@ -162,18 +162,17 @@ def write_control_file(path, package_info: Package):
 # after creating all the neccessary folder stucture this command build a deb package from the path
 def create_deb_package(path):
     try:
-        subprocess.check_output(
-            f"dpkg --build {path}", shell=True, stderr=STDOUT)
+        print(f"[*] Creating .deb package - {path}")
+        subprocess.check_output(f"dpkg --build {path}", shell=True, stderr=STDOUT)
     except CalledProcessError as exc:
         print(exc.output)
         raise exc
 
 
-# creates a temp folder in which to be built Debian packages are compiled and build
+# create build folder and compile packages into it
 def build_packages():
-    # Create `temp` directory
-    temp = Path(f'temp')
-    temp.mkdir(parents=True, exist_ok=True)
+    # Create `build` directory
+    Path(f'build').mkdir(parents=True, exist_ok=True)
 
     # Build All
     for package_class in Packages.values():
@@ -183,10 +182,6 @@ def build_packages():
         # Build
         print(f"[🔨] Building Package: {package.package_name}")
         package.build()
-
-    # Delete Temp Folder
-    shutil.rmtree(temp)
-
 
 # creates the structure used by APT to work
 def init_ubuntu_folder():
@@ -199,7 +194,7 @@ def init_ubuntu_folder():
             "gpg --armor --export \"developer-software@appcove.com\"", shell=True)
         key_file.write(key)
 
-    for deb_file in glob.glob(r'temp/*.deb'):
+    for deb_file in glob.glob(r'build/*.deb'):
         shutil.move(deb_file, f"ubuntu/dists/{UBUNTU_CODENAME}/main/binary-amd64")
 
     os.chdir("ubuntu")

--- a/build_scripts/common.py
+++ b/build_scripts/common.py
@@ -16,7 +16,7 @@ Packages = {}
 
 # Ubuntu Version Constants
 UBUNTU_VERSION = "24.04"
-UBUNTU_CODENAME = "noble"
+UBUNTU_CODENAME = "stable"
 
 class Package(object):
     package_name = None
@@ -104,31 +104,14 @@ class RustPackage(Package):
         write_control_file(BUILD_FOLDER, self)
         create_deb_package(f"{BUILD_FOLDER}")
 
-class Release(Package):
+class InstallAll(Package):
     def build(self):
         BUILD_FOLDER = f"build/ads-{self.package_name}_{self.version}custom{UBUNTU_VERSION}_{self.arch}"
 
         # add path to bins
         Path(f'./{BUILD_FOLDER}/etc/profile.d').mkdir(parents=True, exist_ok=True)
-        with open(f'{BUILD_FOLDER}/etc/profile.d/10-ads-release.sh', "w") as release_file:
+        with open(f'{BUILD_FOLDER}/etc/profile.d/10-ads-path-modify.sh', "w") as release_file:
             release_file.write("export PATH=\"$PATH:/opt/ads/bin\"")
-
-        # add key and list file
-        Path(f'{BUILD_FOLDER}/DEBIAN').mkdir(parents=True, exist_ok=True)
-        with open(f'{BUILD_FOLDER}/DEBIAN/postinst', "w") as release_file:
-            release_file.write("""
-curl -s --compressed "https://raw.githubusercontent.com/appcove/developer-software/refs/heads/website/ubuntu/KEY.gpg" | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/appcove-developer-software.gpg
-sudo curl -s --compressed -o /etc/apt/sources.list.d/appcove-developer-software.list \"https://raw.githubusercontent.com/appcove/developer-software/refs/heads/website/ubuntu/dists/jammy/appcove-developer-software.list\"""")
-
-        Path(f'{BUILD_FOLDER}/DEBIAN').mkdir(parents=True, exist_ok=True)
-        write_control_file(BUILD_FOLDER, self)
-        os.chmod(f'{BUILD_FOLDER}/DEBIAN/postinst', 0o775)
-
-        create_deb_package(f"{BUILD_FOLDER}")
-
-class InstallAll(Package):
-    def build(self):
-        BUILD_FOLDER = f"build/ads-{self.package_name}_{self.version}custom{UBUNTU_VERSION}_{self.arch}"
 
         Path(f'{BUILD_FOLDER}/DEBIAN').mkdir(parents=True, exist_ok=True)
         with open(f'{BUILD_FOLDER}/DEBIAN/postinst', "w") as release_file:
@@ -213,7 +196,7 @@ def init_ubuntu_folder():
 
     with open("main/binary-amd64/Release", 'w') as file:
         file.write(
-            f"Archive: {UBUNTU_CODENAME}\nVersion: 22.04\nComponent: main\nOrigin: Ubuntu\nLabel: Ubuntu\nArchitecture: amd64")
+            f"Archive: {UBUNTU_CODENAME}\nVersion: {UBUNTU_VERSION}\nComponent: main\nOrigin: Ubuntu\nLabel: Ubuntu\nArchitecture: amd64")
 
     with open("ftp_release.conf", 'w') as file:
         file.write(

--- a/build_scripts/packages.py
+++ b/build_scripts/packages.py
@@ -1,4 +1,10 @@
-from common import RustPackage, InstallAll, Release, Tool
+from common import RustPackage, InstallAll, Tool
+
+class everything(InstallAll, Tool):
+    version = "1.1.0"
+    depends = "fzf, jq, tig, git, git-lfs, sshfs, vim, rsync, curl, tree"
+    homepage = "https://github.com/appcove/developer-software"
+    description = "This package install all the available tools in AppcoveDevSoftware"
 
 # Tool Packages
 class bat(RustPackage, Tool):
@@ -89,17 +95,3 @@ class jaq(RustPackage, Tool):
     version = "2.3.0"
     homepage = "https://github.com/01mf02/jaq"
     description = "Just another JSON query tool "
-
-
-# Meta-Pacakges
-class everything(InstallAll, Tool):
-    version = "1.1.0"
-    depends = "fzf, jq, tig, git, git-lfs, sshfs, vim, rsync, curl, tree"
-    homepage = "https://github.com/appcove/developer-software"
-    description = "This package install all the available tools in AppcoveDevSoftware"
-
-class release(Release, Tool):
-    package_name = 'release'
-    version = "1.1.0"
-    homepage = "https://github.com/appcove/developer-software"
-    description = "This package install neccesary files for AppcoveDevSoftware"


### PR DESCRIPTION
- `ads-release` meta package folded into `ads-everything`
- `build` folder not deleted by Python script upon deletion
- Moved to `stable` codename, from `noble`
- Updated Links to use GitHub Pages, not raw head references.